### PR TITLE
Shift click on a tag, highlights all states matching that tag

### DIFF
--- a/src/statemap-svg.js
+++ b/src/statemap-svg.js
@@ -1064,7 +1064,7 @@ var timebarRemoveSubbar = function (timebar)
 	timebar.subbar = undefined;
 };
 
-var stateselTagvalSelect = function (evt, tagval)
+var stateselTagvalSelect = function (evt, tagval, all_states)
 {
 	var tagdefs = {};
 	var i, entity;
@@ -1111,7 +1111,7 @@ var stateselTagvalSelect = function (evt, tagval)
 	 * tag value.
 	 */
 	for (i = 0; i < tags.length; i++) {
-		if (tags[i].state != state)
+		if (tags[i].state != state && !all_states)
 			continue;
 
 		if (tags[i][g_tagsel.tag] != tagval)
@@ -1142,7 +1142,7 @@ var stateselTagvalSelect = function (evt, tagval)
 				if (!datum.s[state])
 					continue;
 			} else {
-				if (datum.s != state)
+				if (datum.s != state && !all_states)
 					continue;
 			}
 
@@ -1321,8 +1321,8 @@ var stateselUpdate = function ()
 	var ttl = 0;
 	var ellipsis = false;
 
-	var click = function (tv) {
-		return (function (evt) { stateselTagvalSelect(evt, tv); });
+	click = function (tv) {
+		return (function (evt) { stateselTagvalSelect(evt, tv, event.shiftKey); });
 	};
 
 	for (i = 0; i <= sorted.length; i++) {


### PR DESCRIPTION
If, for example, you are tagging your states with the request id, otel trace ID, span ID, etc, you may want to see all the work that is coming from the same request.

By default, clicking on a tag only shows the same states that contain the tag. This change allows you to hold down shift to see all the states which match the tag.